### PR TITLE
child _settings can override parent theme settings

### DIFF
--- a/scss/app.scss
+++ b/scss/app.scss
@@ -1,5 +1,5 @@
-@import "../FoundationPress/scss/app";
 @import "settings";
+@import "../FoundationPress/scss/app";
 @import "custom"; // Custom child theme styles
 @import "foundation";
 


### PR DESCRIPTION
Hi,
Settings should be imported before the parent FoundationPress app in order to make it possible to override them from child theme.

Thanks
